### PR TITLE
chore: update jwt-go to secure version 3.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module vulnerable-app
 
 go 1.19
 
-require github.com/dgrijalva/jwt-go v3.2.0+incompatible // Known vulnerability in JWT handling
+require github.com/dgrijalva/jwt-go v3.2.1+incompatible // Updated to fix CVE-2020-26160


### PR DESCRIPTION
Updates jwt-go to v3.2.1 to fix CVE-2020-26160

### Security Update Details
- **Package:** github.com/dgrijalva/jwt-go
- **From Version:** v3.2.0
- **To Version:** v3.2.1
- **CVE:** CVE-2020-26160
- **Severity:** High
- **Description:** Token verification bypass due to flawed "None" algorithm implementation

### Validation
- Updated go.mod file
- Dependency version bumped to secure version
- Vulnerability should be resolved after this update

Please review and merge this security update.