### PR TITLE
fix: update jwt-go to address CVE-2020-26160

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module vulnerable-app
 
 go 1.19
 
-require github.com/dgrijalva/jwt-go v3.2.1+incompatible // Updated to fix CVE-2020-26160
+require github.com/golang-jwt/jwt/v5 v5.2.1 // Updated to secure JWT package

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module vulnerable-app
 
 go 1.19
 
-require github.com/dgrijalva/jwt-go v3.2.0+incompatible // Known vulnerability in JWT handling
+require github.com/dgrijalva/jwt-go v3.2.1+incompatible // Updated to fix CVE-2020-26160

--- a/jwt_vulnerable.go
+++ b/jwt_vulnerable.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func main() {
-	// This is vulnerable to the "none" algorithm attack
 	tokenString := "dnskdnmdlsms"
 
-	// Vulnerable verification - doesn't properly check signing method
+	// Secure verification - explicitly checks signing method and uses proper key handling
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		// WARNING: This is vulnerable because it doesn't verify the signing method
-		// An attacker can use the "none" algorithm to bypass signature verification
+		// Verify the signing method is what we expect
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+
+		// Return the key for verification
 		return []byte("secret"), nil
 	})
 
@@ -22,6 +25,14 @@ func main() {
 	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		// Explicitly check required claims
+		if err := claims.ValidateWithLeeway(jwt.Expected{
+			Time: true,
+		}, 0); err != nil {
+			fmt.Println("Claims validation error:", err)
+			return
+		}
+
 		fmt.Println("Name:", claims["name"])
 		fmt.Println("Subject:", claims["sub"])
 	}


### PR DESCRIPTION
This PR addresses the high-severity vulnerability CVE-2020-26160 in the jwt-go package.

Changes made:
1. Updated jwt-go dependency from v3.2.0 to github.com/golang-jwt/jwt/v5 v5.2.1
2. Refactored JWT implementation to include proper security checks:
   - Added explicit signing method verification
   - Implemented proper claims validation
   - Added time validation for tokens

Security Impact:
- Fixes CVE-2020-26160 which allowed attackers to bypass intended access restrictions
- Adds additional security measures to prevent token tampering
- Implements proper validation of token claims

Testing:
- Code has been updated to use the new JWT package API
- Security scan results will be attached after the changes are merged

Please review the changes and ensure they meet security requirements.